### PR TITLE
redux-thunkを使ってAPI経由でクイズデータを取得するテストコードの追加差分

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8161,6 +8161,12 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10859,6 +10865,15 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.3.tgz",
+      "integrity": "sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@babel/node": "^7.6.3",
     "@babel/preset-env": "^7.6.3",
     "babel-jest": "^24.9.0",
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "redux-mock-store": "^1.5.3"
   }
 }

--- a/src/__tests__/actions/quizActionCreator.spec.js
+++ b/src/__tests__/actions/quizActionCreator.spec.js
@@ -1,0 +1,62 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import axios from 'axios';
+import {
+  FETCH_QUIZZES_REQUEST,
+  FETCH_QUIZZES_SUCCESS,
+  FETCH_QUIZZES_FAILURE,
+  fetchQuizzes
+} from '../../actions/quizActionCreator';
+
+jest.mock('axios');
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('quizActionCreatorのテスト', () => {
+  it('fetch成功時、FETCH_QUIZZES_SUCCESSと一緒にクイズデータが渡される', async () => {
+    const expectedResults = [
+      'クイズ1',
+      'クイズ2',
+    ];
+    axios.get.mockResolvedValue({
+      data: {
+        results: expectedResults
+      }
+    });
+
+    const store = mockStore();
+    await store.dispatch(fetchQuizzes());
+
+    expect(store.getActions()).toEqual([
+      {
+        type: FETCH_QUIZZES_REQUEST
+      },
+      {
+        type: FETCH_QUIZZES_SUCCESS,
+        data: expectedResults
+      }
+    ]);
+  });
+
+  it('fetch失敗時、FETCH_QUIZZES_FAILUREと一緒にエラー情報が渡される', async () => {
+    const expectedError = {
+      message: 'ダミーエラーメッセージ'
+    };
+    axios.get.mockRejectedValue(expectedError);
+
+    const store = mockStore();
+    await store.dispatch(fetchQuizzes());
+
+    expect(store.getActions()).toEqual([
+      {
+        type: FETCH_QUIZZES_REQUEST
+      },
+      {
+        type: FETCH_QUIZZES_FAILURE,
+        error: expectedError
+      }
+    ]);
+  });
+});
+


### PR DESCRIPTION
「【redux-thunk】APIを使った非同期アクションのテストを作成する」

で追加したコード差分を確認するためのプルリクエスト。